### PR TITLE
Move intersection tests to Hittable

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -llvm-header-guard,
   -llvmlibc-callee-namespace,
   -llvmlibc-implementation-in-namespace,
+  -llvmlibc-inline-function-decl,
   -llvmlibc-restrict-system-libc-headers,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
@@ -22,6 +23,7 @@ Checks: >
   -readability-avoid-nested-conditional-operator,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
+  -readability-math-missing-parentheses,
   -readability-uppercase-literal-suffix
 
 FormatStyle: file

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCE_FILES
     camera/camera.cpp
     collisions/aabb.cpp
     collisions/bvh_node.cpp
+    collisions/hittable.cpp
     collisions/intersection.cpp
     collisions/ray.cpp
     geometry/geometry_object.cpp

--- a/src/collisions/bvh_node.hpp
+++ b/src/collisions/bvh_node.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -15,14 +14,13 @@ class BVHNode : public Hittable {
     std::shared_ptr<Hittable> left;
     std::shared_ptr<Hittable> right;
     AABB aabb;
-    static std::atomic<std::size_t> intersection_tests; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
   public:
     BVHNode(const std::vector<std::shared_ptr<Hittable>>& objects, float t0, float t1);
     BVHNode(const std::vector<std::shared_ptr<Hittable>>& objects, std::size_t start, std::size_t end, float t0, float t1);
-    std::optional<Intersection> intersect(const Ray& ray) const override;
+    std::optional<Intersection> intersect_impl(const Ray& ray) const override;
     AABB bounding_box(float t0, float t1) const override;
-    static std::size_t get_intersection_tests();
+    std::size_t get_intersection_tests() const;
 };
 
 } // namespace raytracer::collisions

--- a/src/collisions/hittable.cpp
+++ b/src/collisions/hittable.cpp
@@ -1,0 +1,19 @@
+#include <cstddef>
+#include <optional>
+
+#include "collisions/hittable.hpp"
+#include "collisions/intersection.hpp"
+#include "collisions/ray.hpp"
+
+namespace raytracer::collisions {
+
+std::optional<Intersection> Hittable::intersect(const Ray& ray) {
+    ++intersection_tests;
+    return intersect_impl(ray);
+}
+
+std::size_t Hittable::get_intersection_tests() const {
+    return intersection_tests;
+}
+
+} // namespace raytracer::collisions

--- a/src/collisions/hittable.hpp
+++ b/src/collisions/hittable.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <optional>
 
 #include "aabb.hpp"
@@ -9,14 +10,19 @@
 namespace raytracer::collisions {
 
 class Hittable {
+  protected:
+    std::atomic<std::size_t> intersection_tests;
+
   public:
     Hittable() = default;
-    Hittable(const Hittable&) = default;
+    Hittable(const Hittable&) = delete;
     Hittable(Hittable&&) = delete;
-    Hittable& operator=(const Hittable&) = default;
+    Hittable& operator=(const Hittable&) = delete;
     Hittable& operator=(Hittable&&) = delete;
     virtual ~Hittable() = default;
-    virtual std::optional<Intersection> intersect(const Ray& ray) const = 0;
+    std::size_t get_intersection_tests() const;
+    std::optional<Intersection> intersect(const Ray& ray);
+    virtual std::optional<Intersection> intersect_impl(const Ray& ray) const = 0;
     virtual AABB bounding_box(float t0, float t1) const = 0;
 };
 

--- a/src/geometry/geometry_object.hpp
+++ b/src/geometry/geometry_object.hpp
@@ -11,9 +11,9 @@ class GeometryObject : public collisions::Hittable {
 
   public:
     explicit GeometryObject(const materials::Material* m);
-    GeometryObject(const GeometryObject& other) = default;
+    GeometryObject(const GeometryObject& other) = delete;
     GeometryObject(GeometryObject&& other) = delete;
-    GeometryObject& operator=(const GeometryObject& other) = default;
+    GeometryObject& operator=(const GeometryObject& other) = delete;
     GeometryObject& operator=(GeometryObject&& other) = delete;
     ~GeometryObject() override = default;
     virtual std::pair<float, float> get_uv(const glm::vec3& p) const = 0;

--- a/src/geometry/moving_sphere.cpp
+++ b/src/geometry/moving_sphere.cpp
@@ -23,7 +23,7 @@ glm::vec3 MovingSphere::get_center(float time) const {
     return center1 + ((time - time1) / (time2 - time1)) * (center2 - center1);
 }
 
-std::optional<collisions::Intersection> MovingSphere::intersect(const collisions::Ray& ray) const {
+std::optional<collisions::Intersection> MovingSphere::intersect_impl(const collisions::Ray& ray) const {
     const auto origin = ray.get_origin();
     const auto direction = ray.get_direction();
     const auto center = get_center(ray.get_time());

--- a/src/geometry/moving_sphere.hpp
+++ b/src/geometry/moving_sphere.hpp
@@ -23,7 +23,7 @@ class MovingSphere : public GeometryObject {
   public:
     MovingSphere(glm::vec3 c1, glm::vec3 c2, float r, float t1, float t2, const materials::Material* m);
     glm::vec3 get_center(float time) const;
-    std::optional<collisions::Intersection> intersect(const collisions::Ray& ray) const override;
+    std::optional<collisions::Intersection> intersect_impl(const collisions::Ray& ray) const override;
     collisions::AABB bounding_box(float t0, float t1) const override;
     std::pair<float, float> get_uv(const glm::vec3& p) const override;
 };

--- a/src/geometry/sphere.cpp
+++ b/src/geometry/sphere.cpp
@@ -19,7 +19,7 @@ namespace raytracer::geometry {
 Sphere::Sphere(const glm::vec3& c, float r, const materials::Material* m)
     : GeometryObject(m), center(c), radius(r) {}
 
-std::optional<collisions::Intersection> Sphere::intersect(const collisions::Ray& ray) const {
+std::optional<collisions::Intersection> Sphere::intersect_impl(const collisions::Ray& ray) const {
     const auto origin = ray.get_origin();
     const auto direction = ray.get_direction();
     const auto r = center - origin;

--- a/src/geometry/sphere.hpp
+++ b/src/geometry/sphere.hpp
@@ -19,7 +19,7 @@ class Sphere : public GeometryObject {
 
   public:
     Sphere(const glm::vec3& c, float r, const materials::Material* m);
-    std::optional<collisions::Intersection> intersect(const collisions::Ray& ray) const override;
+    std::optional<collisions::Intersection> intersect_impl(const collisions::Ray& ray) const override;
     collisions::AABB bounding_box(float t0, float t1) const override;
     std::pair<float, float> get_uv(const glm::vec3& p) const override;
 };

--- a/src/materials/image_texture.cpp
+++ b/src/materials/image_texture.cpp
@@ -9,7 +9,7 @@
 namespace raytracer::materials {
 
 ImageTexture::ImageTexture(const std::string& filename)
-    : fdata(stbi_loadf(filename.c_str(), &width, &height, &num_channels, 3)) {
+    : fdata(stbi_loadf(filename.c_str(), &width, &height, &num_channels, 3)) { // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
 }
 
 ImageTexture::~ImageTexture() {
@@ -20,8 +20,8 @@ glm::vec3 ImageTexture::value(float u, float v, const glm::vec3& /*p*/) const {
     if (width <= 0 || height <= 0) {
         return {1, 0, 1};
     }
-    const auto i = static_cast<int>(u * (width - 1));
-    const auto j = static_cast<int>((1 - v) * (height - 1));
+    const auto i = static_cast<int>(u * static_cast<float>(width - 1));
+    const auto j = static_cast<int>((1 - v) * static_cast<float>(height - 1));
     const auto base = num_channels * (j * width + i);
     return {fdata[base], fdata[base + 1], fdata[base + 2]}; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }

--- a/src/raytracer.cpp
+++ b/src/raytracer.cpp
@@ -74,7 +74,7 @@ void Raytracer::write_framebuffer(const std::string& filename) const {
     ofs.open(filename, std::ios_base::out | std::ios_base::trunc);
     ofs << "P6\n"
         << WIDTH << ' ' << HEIGHT << "\n255\n";
-    for (std::size_t i = 0; i < WIDTH * HEIGHT; ++i) {
+    for (auto i = 0u; i < WIDTH * HEIGHT; ++i) {
         for (auto j = 0; j < 3; ++j) {
             ofs << static_cast<unsigned char>(255 * std::max(0.0F, std::min(1.0F, std::sqrt(framebuffer[i][j]))));
         }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -18,11 +18,13 @@
 
 namespace raytracer::utils {
 
+namespace {
 std::size_t get_terminal_width() {
     struct winsize ws{};
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     return ws.ws_col;
 }
+} // namespace
 
 void show_progress(std::size_t percent, std::size_t total_length) {
     // 1 space char + 1 [ char + 5 chars for percentage display + 1 ] char = 8 chars

--- a/tests/camera_unit_test.cpp
+++ b/tests/camera_unit_test.cpp
@@ -11,12 +11,14 @@
 
 namespace raytracer::tests::camera {
 
+namespace {
 void require_vec_equal(const glm::vec3& vec1, const glm::vec3& vec2) {
     static constexpr auto MARGIN = 0.00001;
     REQUIRE_THAT(vec1.x, Catch::Matchers::WithinAbs(vec2.x, MARGIN));
     REQUIRE_THAT(vec1.y, Catch::Matchers::WithinAbs(vec2.y, MARGIN));
     REQUIRE_THAT(vec1.z, Catch::Matchers::WithinAbs(vec2.z, MARGIN));
 }
+} // namespace
 
 TEST_CASE("Default camera settings", "[camera]") {
     auto origin = glm::vec3(0, 0, 0);

--- a/tests/image_texture_unit_test.cpp
+++ b/tests/image_texture_unit_test.cpp
@@ -10,21 +10,30 @@
 
 namespace raytracer::tests::materials {
 
+namespace {
 void require_vec_equal(const glm::vec3& vec1, const glm::vec3& vec2) {
     static constexpr auto MARGIN = 0.00001;
     REQUIRE_THAT(vec1.x, Catch::Matchers::WithinAbs(vec2.x, MARGIN));
     REQUIRE_THAT(vec1.y, Catch::Matchers::WithinAbs(vec2.y, MARGIN));
     REQUIRE_THAT(vec1.z, Catch::Matchers::WithinAbs(vec2.z, MARGIN));
 }
+} // namespace
 
 TEST_CASE("Mango texture values", "[image texture]") {
     const auto data_dir = utils::data_directory_path();
-    const auto texture = raytracer::materials::ImageTexture((data_dir.value() / std::filesystem::path("mango.png")).string());
+    const auto texture = raytracer::materials::ImageTexture((data_dir.value() / std::filesystem::path("mango.png")).string()); // NOLINT(bugprone-unchecked-optional-access)
     const glm::vec3 p = {};
     require_vec_equal(texture.value(0, 0, p), glm::vec3{0, 1, 0});
     require_vec_equal(texture.value(1, 0, p), glm::vec3{1, 1, 0});
     require_vec_equal(texture.value(0, 1, p), glm::vec3{0, 0, 0});
     require_vec_equal(texture.value(1, 1, p), glm::vec3{1, 0, 0});
+
+    const auto linear2srgb = 0.215764;
+    require_vec_equal(texture.value(0.5, 0, p), glm::vec3{linear2srgb, 1, 0});
+    require_vec_equal(texture.value(0.5, 1, p), glm::vec3{linear2srgb, 0, 0});
+    require_vec_equal(texture.value(0, 0.5, p), glm::vec3{0, linear2srgb, 0});
+    require_vec_equal(texture.value(1, 0.5, p), glm::vec3{1, linear2srgb, 0});
+    require_vec_equal(texture.value(0.5, 0.5, p), glm::vec3{linear2srgb, linear2srgb, 0});
 }
 
 } // namespace raytracer::tests::materials

--- a/tests/sphere_unit_test.cpp
+++ b/tests/sphere_unit_test.cpp
@@ -1,3 +1,4 @@
+#include <optional>
 #define CATCH_CONFIG_MAIN
 
 #include <catch2/catch_test_macros.hpp>
@@ -13,59 +14,54 @@ namespace raytracer::tests::geometry {
 
 static constexpr auto MARGIN = 0.001;
 
+namespace {
 void require_vec_equal(const glm::vec3& vec1, const glm::vec3& vec2) {
     REQUIRE_THAT(vec1.x, Catch::Matchers::WithinAbs(vec2.x, MARGIN));
     REQUIRE_THAT(vec1.y, Catch::Matchers::WithinAbs(vec2.y, MARGIN));
     REQUIRE_THAT(vec1.z, Catch::Matchers::WithinAbs(vec2.z, MARGIN));
 }
+} // namespace
 
 TEST_CASE("Ray-sphere intersection", "[sphere]") {
-    auto sphere = raytracer::geometry::Sphere(glm::vec3(0, 0, 0), 1, nullptr);
-    auto ray = collisions::Ray(glm::vec3(0, 1, 1), glm::vec3(0, 0, -1));
-    auto expected = collisions::Intersection(1.0, glm::vec3(0, 1, 0), glm::vec3(0, 1, 0), nullptr, 0.25, 1); // NOLINT(readability-magic-numbers)
-    auto intersec = sphere.intersect(ray);
-    if (intersec.has_value()) {
-        REQUIRE_THAT(intersec->get_distance(), Catch::Matchers::WithinAbs(expected.get_distance(), MARGIN));
-        require_vec_equal(intersec->get_position(), expected.get_position());
-        require_vec_equal(intersec->get_normal(), expected.get_normal());
-        REQUIRE(intersec->get_u() == expected.get_u());
-        REQUIRE(intersec->get_v() == expected.get_v());
-    } else {
-        FAIL("No intersection occured.");
-    }
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    auto sphere1 = raytracer::geometry::Sphere(glm::vec3(0, 0, 0), 1, nullptr);
+    auto ray1 = collisions::Ray(glm::vec3(0, 1, 1), glm::vec3(0, 0, -1));
+    auto expected1 = collisions::Intersection(1.0, glm::vec3(0, 1, 0), glm::vec3(0, 1, 0), nullptr, 0.25, 1); // NOLINT(readability-magic-numbers)
+    auto intersec1 = sphere1.intersect(ray1);
+    REQUIRE(intersec1.has_value());
+    REQUIRE_THAT(intersec1->get_distance(), Catch::Matchers::WithinAbs(expected1.get_distance(), MARGIN));
+    require_vec_equal(intersec1->get_position(), expected1.get_position());
+    require_vec_equal(intersec1->get_normal(), expected1.get_normal());
+    REQUIRE(intersec1->get_u() == expected1.get_u());
+    REQUIRE(intersec1->get_v() == expected1.get_v());
 
-    sphere = raytracer::geometry::Sphere(glm::vec3(0, 1, 0), 1, nullptr);
-    ray = collisions::Ray(glm::vec3(0, -1, 0), glm::vec3(0, 1, 0));
-    expected = collisions::Intersection(1.0, glm::vec3(0, 0, 0), glm::vec3(0, -1, 0), nullptr, 0.5, 0);
-    intersec = sphere.intersect(ray);
-    if (intersec.has_value()) {
-        REQUIRE_THAT(intersec->get_distance(), Catch::Matchers::WithinAbs(expected.get_distance(), MARGIN));
-        require_vec_equal(intersec->get_position(), expected.get_position());
-        require_vec_equal(intersec->get_normal(), expected.get_normal());
-        REQUIRE(intersec->get_u() == expected.get_u());
-        REQUIRE(intersec->get_v() == expected.get_v());
-    } else {
-        FAIL("No intersection occured.");
-    }
+    auto sphere2 = raytracer::geometry::Sphere(glm::vec3(0, 1, 0), 1, nullptr);
+    auto ray2 = collisions::Ray(glm::vec3(0, -1, 0), glm::vec3(0, 1, 0));
+    auto expected2 = collisions::Intersection(1.0, glm::vec3(0, 0, 0), glm::vec3(0, -1, 0), nullptr, 0.5, 0);
+    auto intersec2 = sphere2.intersect(ray2);
+    REQUIRE(intersec2.has_value());
+    REQUIRE_THAT(intersec2->get_distance(), Catch::Matchers::WithinAbs(expected2.get_distance(), MARGIN));
+    require_vec_equal(intersec2->get_position(), expected2.get_position());
+    require_vec_equal(intersec2->get_normal(), expected2.get_normal());
+    REQUIRE(intersec2->get_u() == expected2.get_u());
+    REQUIRE(intersec2->get_v() == expected2.get_v());
 
-    sphere = raytracer::geometry::Sphere(glm::vec3(0, 0, 0), 1, nullptr);
-    ray = collisions::Ray(glm::vec3(0, 0, 0), glm::vec3(0, 1, 0));
-    expected = collisions::Intersection(1.0, glm::vec3(0, 1, 0), glm::vec3(0, 1, 0), nullptr, 0.5, 1);
-    intersec = sphere.intersect(ray);
-    if (intersec.has_value()) {
-        REQUIRE_THAT(intersec->get_distance(), Catch::Matchers::WithinAbs(expected.get_distance(), MARGIN));
-        require_vec_equal(intersec->get_position(), expected.get_position());
-        require_vec_equal(intersec->get_normal(), expected.get_normal());
-        REQUIRE(intersec->get_u() == expected.get_u());
-        REQUIRE(intersec->get_v() == expected.get_v());
-    } else {
-        FAIL("No intersection occured.");
-    }
+    auto sphere3 = raytracer::geometry::Sphere(glm::vec3(0, 0, 0), 1, nullptr);
+    auto ray3 = collisions::Ray(glm::vec3(0, 0, 0), glm::vec3(0, 1, 0));
+    auto expected3 = collisions::Intersection(1.0, glm::vec3(0, 1, 0), glm::vec3(0, 1, 0), nullptr, 0.5, 1);
+    auto intersec3 = sphere3.intersect(ray3);
+    REQUIRE(intersec3.has_value());
+    REQUIRE_THAT(intersec3->get_distance(), Catch::Matchers::WithinAbs(expected3.get_distance(), MARGIN));
+    require_vec_equal(intersec3->get_position(), expected3.get_position());
+    require_vec_equal(intersec3->get_normal(), expected3.get_normal());
+    REQUIRE(intersec3->get_u() == expected3.get_u());
+    REQUIRE(intersec3->get_v() == expected3.get_v());
 
-    sphere = raytracer::geometry::Sphere(glm::vec3(0, 0, 0), 1, nullptr);
-    ray = collisions::Ray(glm::vec3(0, -2, 0), glm::vec3(1, 0, 0));
-    intersec = sphere.intersect(ray);
-    REQUIRE(!intersec.has_value());
+    auto sphere4 = raytracer::geometry::Sphere(glm::vec3(0, 0, 0), 1, nullptr);
+    auto ray4 = collisions::Ray(glm::vec3(0, -2, 0), glm::vec3(1, 0, 0));
+    auto intersec4 = sphere4.intersect(ray4);
+    REQUIRE(!intersec4.has_value());
+    // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 } // namespace raytracer::tests::geometry


### PR DESCRIPTION
This PR moves the `intersection_tests` member to the `Hittable` class. Therefore, the dynamic cast is no longer needed. Some clang-tidy issues were fixed as well.