### PR TITLE
Fix clang-tidy-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build with clang-tidy
       run: cmake --build build
     - name: Run clang-tidy
-      run: find src tests -name '*.cpp' -o -name '*.hpp' | xargs -P $(nproc) -n 1 clang-tidy-19 -p build -header-filter='^(src|tests)/.*'
+      run: find src tests \( -name '*.cpp' -o -name '*.hpp' \) | xargs -P $(nproc) -n 1 clang-tidy-19 -p build -header-filter='^(src|tests)/.*'
 
   coverage-report:
     name: Coverage report


### PR DESCRIPTION
This MR adds some missing parentheses to the clang-tidy-check.